### PR TITLE
Enable second profile in horusmapper.cfg.example

### DIFF
--- a/horusmapper.cfg.example
+++ b/horusmapper.cfg.example
@@ -11,7 +11,7 @@
 #
 [profile_selection]
 # How many profiles have been defined
-profile_count = 1
+profile_count = 2
 # Index of the default profile (indexing from 1)
 default_profile = 1
 


### PR DESCRIPTION
The docs say that radiosonde_auto_rx should just work, but to make that happen you need profile_2 or something like it. This lets profile_2 be available to be switched to it in the settings page of the webapp.