### PR TITLE
Docker: flask-socketio pinned to 4.3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && \
 
 # Install additional Python packages that aren't available through apt-get.
 RUN pip --no-cache-dir install \
-  flask-socketio \
+  flask-socketio==4.3.2 \
   pytz
 
 # Download and install cusf_predictor_wrapper, and build predictor binary.


### PR DESCRIPTION
Otherwise you get the following error when building: 

```
Collecting bidict>=0.21.0 (from python-socketio>=5.0.2->flask-socketio)
  Could not find a version that satisfies the requirement bidict>=0.21.0 (from python-socketio>=5.0.2->flask-socketio) (from versions: 0.1.5, 0.2.1, 0.3.0, 0.3.1, 0.9.0rc0, 0.9.0.post1, 0.10.0, 0.10.0.post1, 0.11.0, 0.12.0.post1, 0.13.0, 0.13.1, 0.14.0, 0.14.1, 0.14.2, 0.15.0.dev0, 0.15.0.dev1, 0.15.0rc1, 0.15.0, 0.16.0, 0.17.0, 0.17.1, 0.17.2, 0.17.3, 0.17.4, 0.17.5, 0.18.0, 0.18.1, 0.18.2, 0.18.3, 0.18.4)
No matching distribution found for bidict>=0.21.0 (from python-socketio>=5.0.2->flask-socketio)
```