### PR TITLE
Always build eccodes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN case $(uname -m) in \
 # Copy any additional Python packages from the build container.
 COPY --from=build /root/.local /root/.local
 
-# Copy predictor binary and get_wind_data.py from the build container.
+# Copy predictor binary from the build container.
 COPY --from=build /root/cusf_predictor_wrapper-master/src/build/pred \
   /opt/chasemapper/
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+--no-binary eccodes
 cusfpredict
 flask
 flask-socketio


### PR DESCRIPTION
The piwheels`eccodes` wheel appears to have been built on something earlier than Python 3.7, which means it depends on `numpy` 1.19 or earlier. - https://github.com/ecmwf/eccodes-python/blob/4c08b49b7115d3af2a8575160347cbc38a20af4d/setup.py#L40-L41.

Ideally we want the latest `numpy`, so lets build `eccodes` to ensure it knows we are on Python 3.7.

