### PR TITLE
Automatic weekly build

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -8,6 +8,8 @@ on:
       - 'v*'
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: '15 14 * * 5'
 
 jobs:
   build:


### PR DESCRIPTION
This will both keep the wheel cache warm, as well as ensure that we don't have any breakages waiting for us do to upstream changes in dependencies.

Runs 2:15pm on a Friday UTC. Time and day picked at random.